### PR TITLE
Cover push to latest tag on Docker Hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,4 @@ publish:
 	echo "$(DOCKER_PASSWORD)" | docker login -u "$(DOCKER_USERNAME)" --password-stdin
 	@echo "==> Pushing built image..."
 	docker push $(DOCKER_IMG):$(TRAVIS_TAG)
+	docker push $(DOCKER_IMG):latest


### PR DESCRIPTION
We should have latest tag present and up to date on Docker Hub

Co-authored-by: Elliot Williams <elliot.williams@form3.tech>