### PR TITLE
Wrapped proxy's modify response function in a mutex

### DIFF
--- a/internal/app/concurrent_proxy_stage_test.go
+++ b/internal/app/concurrent_proxy_stage_test.go
@@ -56,6 +56,12 @@ func NewConcurrentProxyStage(t *testing.T) (*ConcurrentProxyStage, *ConcurrentPr
 		pact:  pact,
 		proxy: proxy,
 	}
+
+	t.Cleanup(func() {
+		pactproxy.Configuration(adminURL.String()).Reset()
+		pact.Teardown()
+	})
+
 	return s, s, s
 }
 

--- a/internal/app/concurrent_proxy_stage_test.go
+++ b/internal/app/concurrent_proxy_stage_test.go
@@ -1,0 +1,239 @@
+package app
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/form3tech-oss/pact-proxy/pkg/pactproxy"
+	"github.com/pact-foundation/pact-go/dsl"
+	log "github.com/sirupsen/logrus"
+)
+
+type ConcurrentProxyStage struct {
+	t                                  *testing.T
+	proxy                              *pactproxy.PactProxy
+	pact                               *dsl.Pact
+	modifiedNameStatusCode             int
+	modifiedAddressStatusCode          int
+	concurrentUserRequestsPerSecond    int
+	concurrentUserRequestsDuration     time.Duration
+	concurrentAddressRequestsPerSecond int
+	concurrentAddressRequestsDuration  time.Duration
+	userPactResult                     error
+	addressPactResult                  error
+	userResponses                      []*http.Response
+	addressResponses                   []*http.Response
+}
+
+func NewConcurrentProxyStage(t *testing.T) (*ConcurrentProxyStage, *ConcurrentProxyStage, *ConcurrentProxyStage) {
+	pact := &dsl.Pact{
+		Consumer: "MyConsumer",
+		Provider: "MyProvider",
+		Host:     "localhost",
+	}
+
+	pact.Setup(true)
+	proxy, err := pactproxy.
+		Configuration(adminURL.String()).
+		SetupProxy(proxyURL.String(), fmt.Sprintf("http://%s:%d", pact.Host, pact.Server.Port))
+	if err != nil {
+		t.Logf("Error setting up proxy: %v", err)
+		t.Fail()
+	}
+
+	pact.Server.Port, err = strconv.Atoi(proxyURL.Port())
+	if err != nil {
+		t.Logf("Error parsing server port: %v", err)
+		t.Fail()
+	}
+	s := &ConcurrentProxyStage{
+		t:     t,
+		pact:  pact,
+		proxy: proxy,
+	}
+	return s, s, s
+}
+
+func (s *ConcurrentProxyStage) and() *ConcurrentProxyStage {
+	return s
+}
+
+func (s *ConcurrentProxyStage) a_modified_name_status_code() *ConcurrentProxyStage {
+	s.modifiedNameStatusCode = http.StatusBadGateway
+	return s
+}
+
+func (s *ConcurrentProxyStage) a_modified_address_status_code() *ConcurrentProxyStage {
+	s.modifiedAddressStatusCode = http.StatusConflict
+	return s
+}
+
+func (s *ConcurrentProxyStage) a_pact_that_allows_any_names() *ConcurrentProxyStage {
+	s.pact.
+		AddInteraction().
+		UponReceiving(PostNamePact).
+		WithRequest(dsl.Request{
+			Method:  "POST",
+			Path:    dsl.String("/users"),
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Body:    dsl.MapMatcher{"name": dsl.Regex("any", ".*")},
+		}).
+		WillRespondWith(dsl.Response{
+			Status:  200,
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Body:    map[string]string{"name": "any"},
+		})
+	return s
+}
+
+func (s *ConcurrentProxyStage) a_pact_that_allows_any_address() *ConcurrentProxyStage {
+	s.pact.
+		AddInteraction().
+		UponReceiving(PostAddressPact).
+		WithRequest(dsl.Request{
+			Method:  "POST",
+			Path:    dsl.String("/addresses"),
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Body:    dsl.MapMatcher{"address": dsl.Regex("any", ".*")},
+		}).
+		WillRespondWith(dsl.Response{
+			Status:  200,
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Body:    map[string]string{"address": "any"},
+		})
+	return s
+}
+
+func (s *ConcurrentProxyStage) x_concurrent_user_requests_per_second_are_made_for_y_seconds(x int, y time.Duration) *ConcurrentProxyStage {
+	s.concurrentUserRequestsPerSecond = x
+	s.concurrentUserRequestsDuration = y
+
+	return s
+}
+
+func (s *ConcurrentProxyStage) x_concurrent_address_requests_per_second_are_made_for_y_seconds(x int, y time.Duration) *ConcurrentProxyStage {
+	s.concurrentAddressRequestsPerSecond = x
+	s.concurrentAddressRequestsDuration = y
+
+	return s
+}
+
+func (s *ConcurrentProxyStage) the_concurrent_requests_are_sent() {
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.userPactResult = s.pact.Verify(func() (err error) {
+			i := s.proxy.ForInteraction(PostNamePact)
+			i.AddModifier("$.status", fmt.Sprintf("%d", s.modifiedNameStatusCode), nil)
+			sendConcurrentRequests(s.concurrentUserRequestsPerSecond, s.concurrentUserRequestsDuration, s.makeUserRequest)
+
+			return nil
+		})
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.addressPactResult = s.pact.Verify(func() (err error) {
+			i := s.proxy.ForInteraction(PostAddressPact)
+			i.AddModifier("$.status", fmt.Sprintf("%d", s.modifiedAddressStatusCode), nil)
+			sendConcurrentRequests(s.concurrentAddressRequestsPerSecond, s.concurrentAddressRequestsDuration, s.makeAddressRequest)
+
+			return nil
+		})
+	}()
+
+	wg.Wait()
+}
+
+func (s *ConcurrentProxyStage) makeUserRequest() {
+	u := fmt.Sprintf("http://localhost:%s/users", proxyURL.Port())
+	req, err := http.NewRequest("POST", u, strings.NewReader(`{"name":"jim"}`))
+	if err != nil {
+		s.t.Error(err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.t.Error(err)
+		return
+	}
+	s.userResponses = append(s.userResponses, res)
+}
+
+func (s *ConcurrentProxyStage) makeAddressRequest() {
+	u := fmt.Sprintf("http://localhost:%s/addresses", proxyURL.Port())
+	req, err := http.NewRequest("POST", u, strings.NewReader(`{"address":"test"}`))
+	if err != nil {
+		s.t.Error(err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.t.Error(err)
+		return
+	}
+	s.addressResponses = append(s.addressResponses, res)
+}
+
+func sendConcurrentRequests(requests int, d time.Duration, f func()) {
+	log.Infof("sending %d concurrent requests per second for %d", requests, d)
+	timer := time.NewTimer(d)
+	stop := make(chan bool)
+
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				for i := 0; i < requests; i++ {
+					f()
+				}
+			}
+		}
+	}()
+
+	<-timer.C
+	stop <- true
+}
+
+func (s *ConcurrentProxyStage) all_the_user_responses_should_have_the_right_status_code() *ConcurrentProxyStage {
+	expectedLen := s.concurrentUserRequestsPerSecond * int(s.concurrentUserRequestsDuration/time.Second)
+	if len(s.userResponses) != expectedLen {
+		s.t.Errorf("expected %d user responses, but got %d", expectedLen, len(s.userResponses))
+	}
+	for _, res := range s.userResponses {
+		if s.modifiedNameStatusCode != res.StatusCode {
+			s.t.Errorf("expected user status code of %d, but got %d", s.modifiedNameStatusCode, res.StatusCode)
+		}
+	}
+
+	return s
+}
+
+func (s *ConcurrentProxyStage) all_the_address_responses_should_have_the_right_status_code() *ConcurrentProxyStage {
+	expectedLen := s.concurrentAddressRequestsPerSecond * int(s.concurrentAddressRequestsDuration/time.Second)
+	if len(s.addressResponses) != expectedLen {
+		s.t.Errorf("expected %d address responses, but got %d", expectedLen, len(s.addressResponses))
+	}
+	for _, res := range s.addressResponses {
+		if s.modifiedAddressStatusCode != res.StatusCode {
+			s.t.Errorf("expected address status code of %d, but got %d", s.modifiedAddressStatusCode, res.StatusCode)
+		}
+	}
+
+	return s
+}

--- a/internal/app/concurrent_proxy_test.go
+++ b/internal/app/concurrent_proxy_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConcurrentRequestsForDifferentModifiersHaveTheCorrectResponses(t *testing.T) {
+	given, when, then := NewConcurrentProxyStage(t)
+
+	given.
+		a_pact_that_allows_any_names().and().
+		a_modified_name_status_code().and().
+		a_pact_that_allows_any_address().and().
+		a_modified_address_status_code()
+
+	when.
+		x_concurrent_user_requests_per_second_are_made_for_y_seconds(5, 5*time.Second).and().
+		x_concurrent_address_requests_per_second_are_made_for_y_seconds(5, 5*time.Second).and().
+		the_concurrent_requests_are_sent()
+
+	then.
+		all_the_user_responses_should_have_the_right_status_code().and().
+		all_the_address_responses_should_have_the_right_status_code()
+}

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -252,11 +252,13 @@ func modifyResponseFunc(modifiers []*interactionModifier) func(response *http.Re
 			}
 			b, err := ioutil.ReadAll(response.Body)
 			if err != nil {
+				log.Error(err)
 				return err
 			}
 
 			modifiedBody, err := modifier.modifyBody(b)
 			if err != nil {
+				log.Error(err)
 				return err
 			}
 

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -30,9 +30,6 @@ func StartProxy(server *http.ServeMux, target *url.URL) {
 	})
 
 	server.HandleFunc("/interactions/constraints", func(res http.ResponseWriter, req *http.Request) {
-		modifyResponseMutex.Lock()
-		defer modifyResponseMutex.Unlock()
-		proxy.ModifyResponse = nil
 		constraintBytes, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			httpresponse.Errorf(res, http.StatusBadRequest, "unable to read constraint. %s", err.Error())
@@ -56,9 +53,6 @@ func StartProxy(server *http.ServeMux, target *url.URL) {
 	})
 
 	server.HandleFunc("/interactions/modifiers", func(res http.ResponseWriter, req *http.Request) {
-		modifyResponseMutex.Lock()
-		defer modifyResponseMutex.Unlock()
-		proxy.ModifyResponse = nil
 		modifierBytes, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			httpresponse.Errorf(res, http.StatusBadRequest, "unable to read modifier. %s", err.Error())
@@ -137,9 +131,6 @@ func StartProxy(server *http.ServeMux, target *url.URL) {
 	})
 
 	server.HandleFunc("/interactions/wait", func(res http.ResponseWriter, req *http.Request) {
-		modifyResponseMutex.Lock()
-		defer modifyResponseMutex.Unlock()
-		proxy.ModifyResponse = nil
 		waitFor := req.URL.Query().Get("interaction")
 		waitForCount, err := strconv.Atoi(req.URL.Query().Get("count"))
 		if err != nil {

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -91,6 +91,7 @@ func StartProxy(server *http.ServeMux, target *url.URL) {
 		defer modifyResponseMutex.Unlock()
 		proxy.ModifyResponse = nil
 		if req.Method == http.MethodDelete {
+			log.Info("deleting interactions")
 			proxy.ServeHTTP(res, req)
 			interactions.Clear()
 			return


### PR DESCRIPTION
We use the proxy's modify response functionality to modify responses on
their return trip to clients. This allows us to modify status codes and
body data as configured by the client.

However, this function is a field on the proxy and needs to be able to
operate on all concurrent requests. Much of the matching logic for the
response modifiers depends on matching on the request body, which is not
possible when handling a response.

As a result, we need to make sure we only modify a single response at a
time, even when the proxy is subject to concurrent load. The simplest
way of ensuring this is to wrap changes to the response modifier
function in a mutex, which fixes that test case also included in this
commit (which highlights the concurrency problems).