### PR TITLE
enable generation of pact by proxying /pact route

### DIFF
--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -22,12 +22,15 @@ func StartProxy(server *http.ServeMux, target *url.URL) {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	notify := NewNotify()
 
-	server.HandleFunc("/interactions/verification", func(res http.ResponseWriter, req *http.Request) {
+	proxyPass := func(res http.ResponseWriter, req *http.Request) {
 		modifyResponseMutex.Lock()
 		defer modifyResponseMutex.Unlock()
 		proxy.ModifyResponse = nil
 		proxy.ServeHTTP(res, req)
-	})
+	}
+
+	server.HandleFunc("/interactions/verification", proxyPass)
+	server.HandleFunc("/pact", proxyPass)
 
 	server.HandleFunc("/interactions/constraints", func(res http.ResponseWriter, req *http.Request) {
 		constraintBytes, err := ioutil.ReadAll(req.Body)

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -15,7 +15,9 @@ func TestConstraintMatches(t *testing.T) {
 		a_constaint_is_added("sam").and().
 		a_request_is_sent_using_the_name("sam")
 
-	then.pact_verification_is_successful()
+	then.
+		pact_verification_is_successful().and().
+		pact_can_be_generated()
 }
 
 func TestConstraintDoesntMatch(t *testing.T) {


### PR DESCRIPTION
Allows `/pact` route to be proxied directly