### PR TITLE
Avoid locking by using custom response writer

### DIFF
--- a/internal/app/pactproxy/response_modification_writer.go
+++ b/internal/app/pactproxy/response_modification_writer.go
@@ -1,0 +1,56 @@
+package pactproxy
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+)
+
+type ResponseModificationWriter struct {
+	res          http.ResponseWriter
+	interactions []*interaction
+	statusCode   int
+}
+
+func (m *ResponseModificationWriter) Header() http.Header {
+	return m.res.Header()
+}
+
+func (m *ResponseModificationWriter) Write(b []byte) (written int, err error) {
+	written = len(b)
+
+	for _, i := range m.interactions {
+		b, err = i.Modifiers.modifyBody(b)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	m.Header().Set("Content-Length", strconv.Itoa(len(b)))
+	m.res.WriteHeader(m.statusCode)
+	actualBytes, err := m.res.Write(b)
+	if err != nil {
+		return 0, err
+	}
+
+	if actualBytes != len(b) {
+		return actualBytes, io.ErrShortWrite
+	}
+	return
+}
+
+func (m *ResponseModificationWriter) WriteHeader(statusCode int) {
+	m.statusCode = statusCode
+	for _, i := range m.interactions {
+		ok, code := i.Modifiers.modifyStatusCode()
+		if ok {
+			m.statusCode = code
+			break
+		}
+	}
+
+	contentLength, err := strconv.Atoi(m.Header().Get("Content-Length"))
+	if err != nil || contentLength == 0 {
+		m.res.WriteHeader(m.statusCode)
+	}
+}

--- a/internal/app/proxy_stage_test.go
+++ b/internal/app/proxy_stage_test.go
@@ -412,7 +412,7 @@ func (s *ProxyStage) n_responses_were_received(n int) *ProxyStage {
 
 func (s *ProxyStage) pact_can_be_generated() {
 	u := fmt.Sprintf("http://localhost:%s/pact", proxyURL.Port())
-	req, err := http.NewRequestWithContext(context.Background(),"POST", u, bytes.NewReader([]byte("{\"pact_specification_version\":\"3.0.0\"}")))
+	req, err := http.NewRequestWithContext(context.Background(), "POST", u, bytes.NewReader([]byte("{\"pact_specification_version\":\"3.0.0\"}")))
 	if err != nil {
 		s.t.Error(err)
 		return

--- a/pkg/pactproxy/pactproxy.go
+++ b/pkg/pactproxy/pactproxy.go
@@ -54,7 +54,7 @@ func (p *PactProxy) addConstraint(interaction, pactPath, value string) {
 	}
 }
 
-func (p *PactProxy) addModifier(interaction, path, value string, attempt *int) {
+func (p *PactProxy) addModifier(interaction, path string, value interface{}, attempt *int) {
 	body := map[string]interface{}{
 		"interaction": interaction,
 		"path":        path,
@@ -134,7 +134,7 @@ func (s InteractionSetup) AddConstraint(path, value string) InteractionSetup {
 	return s
 }
 
-func (s InteractionSetup) AddModifier(path, value string, attempt *int) InteractionSetup {
+func (s InteractionSetup) AddModifier(path string, value interface{}, attempt *int) InteractionSetup {
 	s.pactProxy.addModifier(s.interaction, path, value, attempt)
 	return s
 }


### PR DESCRIPTION
Introduces a custom response writer that can modify responses instead of using the `ModifyResponse` function. This avoids the need to have locking when we assign the function.

Also moves the modifiers map and the modification functions into a struct that references all of the modifiers and the associated interaction. This allows `attempt` to be evaluated using the interaction `requestCount` removing the need to have separate variables for each type of modification.