### PR TITLE
Make the pact-proxy support v3 matching rule pattern

### DIFF
--- a/build/package/pact-proxy/Dockerfile
+++ b/build/package/pact-proxy/Dockerfile
@@ -20,6 +20,4 @@ WORKDIR /app
 COPY build/package/$APPNAME/entrypoint.sh /app/
 COPY --from=build-env /go/bin/$APPNAME /app/
 
-RUN ip -4 route list match 0/0 | awk '{print $3 "host.docker.internal"}' >> /etc/hosts
-
 ENTRYPOINT ./entrypoint.sh

--- a/build/package/pact-proxy/entrypoint.sh
+++ b/build/package/pact-proxy/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/dumb-init /bin/sh
 set -e
-
+ip -4 route list match 0/0 | awk '{print $3 "host.docker.internal"}' >> /etc/hosts
 ./pact-proxy

--- a/internal/app/pactproxy/interaction.go
+++ b/internal/app/pactproxy/interaction.go
@@ -167,11 +167,6 @@ func getMatchingRules(request map[string]interface{}) map[string]interface{} {
 		rules = make(map[string]interface{})
 	}
 	rulesMap := rules.(map[string]interface{})
-
-	// flatten the matching rules
-	//flattenedRulesMap := make(map[string]interface{})
-	//flattenRulesMap("$", rulesMap, flattenedRulesMap)
-
 	return rulesMap
 }
 

--- a/internal/app/pactproxy/interaction.go
+++ b/internal/app/pactproxy/interaction.go
@@ -159,11 +159,11 @@ func getPathRegex(matchingRules map[string]interface{}) (string, error) {
 		}
 		matchers, ok := val["matchers"]
 		if !ok {
-			return "", fmt.Errorf("invalid v3 pathRegex no matchers")
+			return "", fmt.Errorf("invalid v3 pathRegex - no matchers found")
 		}
 		matchersArray, ok := matchers.([]interface{})
 		if !ok || len(matchersArray) == 0 {
-			return "", fmt.Errorf("invalid v3 matchers")
+			return "", fmt.Errorf("invalid v3 pathRegex - invalid matchers")
 		}
 
 		for _, matcher := range matchersArray {
@@ -174,17 +174,17 @@ func getPathRegex(matchingRules map[string]interface{}) (string, error) {
 			}
 			regex, ok := matchersStruct["regex"]
 			if !ok {
-				continue
+				return "", fmt.Errorf("invalid v3 pathRegex - \"regex\" field is not found")
 			}
 			_, ok = regex.(string)
 			if !ok {
-				return "", fmt.Errorf("invalid v3 pathRegex invalid regex type")
+				return "", fmt.Errorf("invalid v3 pathRegex - invalid regex type")
 			}
 
 			return regex.(string), nil
 		}
 
-		return "", fmt.Errorf("invalid v3 no regex matcher is found")
+		return "", fmt.Errorf("invalid v3 pathRegex - regex matcher is not found")
 	}
 
 	// no path rule present

--- a/internal/app/pactproxy/interaction_test.go
+++ b/internal/app/pactproxy/interaction_test.go
@@ -374,6 +374,23 @@ func Test_getPathRegex(t *testing.T) {
 			true,
 		},
 		{
+			"v3 pact matching rules - multiple",
+			`{"path":{ "matchers": [
+							{
+								"match": "test"
+							},
+							{
+								"match": "regex",
+								"regex": "1234"
+							}, 
+							{
+								"match": "type"
+							}
+							]}}`,
+			"1234",
+			false,
+		},
+		{
 			"v3 pact matching rules invalid content",
 			`{"path":{ "invalid": [{
 								"match": "regex",
@@ -389,7 +406,7 @@ func Test_getPathRegex(t *testing.T) {
 								"match": "regex",
 								"invalid": "1234"
 							  }]
-}}`,
+					}}`,
 			"",
 			true,
 		},
@@ -401,8 +418,11 @@ func Test_getPathRegex(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.args), &input)
 			assert.NoError(t, err)
 			got, err := getPathRegex(input)
-			if tt.wantErr && err != nil {
-				return
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			}
+			if !tt.wantErr {
+				assert.Nil(t, err)
 			}
 			assert.Equalf(t, tt.want, got, "getPathRegex(%v)", tt.args)
 		})

--- a/internal/app/pactproxy/interaction_test.go
+++ b/internal/app/pactproxy/interaction_test.go
@@ -354,7 +354,7 @@ func Test_getPathRegex(t *testing.T) {
 			true,
 		},
 		{
-			"v3 pact matching rules",
+			"v3 pact matching rules - valid ",
 			`{"path":{ "matchers": [{
 								"match": "regex",
 								"regex": "1234"
@@ -364,7 +364,7 @@ func Test_getPathRegex(t *testing.T) {
 			false,
 		},
 		{
-			"v3 pact matching rules invalid match type",
+			"v3 pact matching rules - invalid match type",
 			`{"path":{ "matchers": [{
 								"match": "invalid",
 								"regex": "1234"
@@ -374,7 +374,7 @@ func Test_getPathRegex(t *testing.T) {
 			true,
 		},
 		{
-			"v3 pact matching rules - multiple",
+			"v3 pact matching rules - multiple valid",
 			`{"path":{ "matchers": [
 							{
 								"match": "test"
@@ -391,7 +391,7 @@ func Test_getPathRegex(t *testing.T) {
 			false,
 		},
 		{
-			"v3 pact matching rules invalid content",
+			"v3 pact matching rules - invalid content",
 			`{"path":{ "invalid": [{
 								"match": "regex",
 								"regex": "1234"
@@ -399,9 +399,15 @@ func Test_getPathRegex(t *testing.T) {
 			"",
 			true,
 		},
-
 		{
-			"v3 pact matching rules invalid match key",
+			"v3 pact matching rules - regex field is not found",
+			`{"path":{ "invalid": [{
+								"match": "regex" }]}}`,
+			"",
+			true,
+		},
+		{
+			"v3 pact matching rules - invalid match key",
 			`{"path":{ "matchers": [{
 								"match": "regex",
 								"invalid": "1234"
@@ -420,8 +426,7 @@ func Test_getPathRegex(t *testing.T) {
 			got, err := getPathRegex(input)
 			if tt.wantErr {
 				assert.NotNil(t, err)
-			}
-			if !tt.wantErr {
+			} else {
 				assert.Nil(t, err)
 			}
 			assert.Equalf(t, tt.want, got, "getPathRegex(%v)", tt.args)

--- a/internal/app/pactproxy/interaction_test.go
+++ b/internal/app/pactproxy/interaction_test.go
@@ -126,7 +126,7 @@ func TestV3MatchingRulesLeadToCorrectConstraints(t *testing.T) {
 		`{
 		"description": "A request to admit a payment",
 		"request": {
-		  "method": "POST",
+		  "method": "POST",	
 		  "path": "/v1/payments/830e5d93-1cd1-4def-953e-6188d7235c38/admissions",
 		  "headers": {
 			"Content-Type": "application/json; charset=utf-8"
@@ -137,6 +137,11 @@ func TestV3MatchingRulesLeadToCorrectConstraints(t *testing.T) {
 		    }
 		  },
 		  "matchingRules": {
+            "path": {
+              "matchers" : [
+                { "match": "regex", "regex": "/v1/payments/[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}/admissions" }
+              ]
+            },
 			"body": {
               "$.data.type" :{
                 "matchers" : [
@@ -178,6 +183,11 @@ func TestV3MatchingRulesLeadToCorrectConstraints(t *testing.T) {
 		    }
 		  },
 		  "matchingRules": {
+            "path": {
+              "matchers" : [
+                { "match": "regex", "regex": "/v1/payments/[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}/admissions" }
+              ]
+            },
 			"body": {
               "$.data.type" :{
                 "matchers" : [

--- a/internal/app/setup_test.go
+++ b/internal/app/setup_test.go
@@ -80,9 +80,10 @@ func setPathOnce() {
 
 func startPactServer(overridePort int) func() *dsl.Pact {
 	pact = &dsl.Pact{
-		Consumer: "MyConsumer",
-		Provider: "MyProvider",
-		Host:     "localhost",
+		Consumer:             "MyConsumer",
+		Provider:             "MyProvider",
+		Host:                 "localhost",
+		SpecificationVersion: 3,
 	}
 
 	pact.Setup(true)


### PR DESCRIPTION
Changes:
- matching rule selection for v2 and v3 pact specifications
- fix for docker build issue for M1 machines