### PR TITLE
Support more types when modifying body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ pact/
 .serverport
 internal/app/pacts/myconsumer-myprovider.json
 
+# logs
+*.log
 
 
 # Visual Studio Code

--- a/internal/app/pactproxy/modifier.go
+++ b/internal/app/pactproxy/modifier.go
@@ -2,6 +2,7 @@ package pactproxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -11,11 +12,20 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+type UnsupportedTypeSpecifiedError struct {
+	receivedType string
+}
+
+func (e UnsupportedTypeSpecifiedError) Error() string {
+	return fmt.Sprintf("Unsupported type specified: %s", e.receivedType)
+}
+
 type interactionModifier struct {
-	Interaction string `json:"interaction"`
-	Path        string `json:"path"`
-	Value       string `json:"value"`
-	Attempt     *int   `json:"attempt"`
+	Interaction string      `json:"interaction"`
+	Path        string      `json:"path"`
+	Value       interface{} `json:"value"`
+	ValueType   string      `json:"type"`
+	Attempt     *int        `json:"attempt"`
 }
 
 type interactionModifiers struct {
@@ -29,6 +39,32 @@ func loadModifier(data []byte) (*interactionModifier, error) {
 	if err != nil {
 		return modifier, errors.Wrap(err, "unable to parse interactionModifier from data")
 	}
+	valueAsString := fmt.Sprintf("%v", modifier.Value)
+	switch modifier.ValueType {
+	case "string":
+		return modifier, nil
+	case "int":
+		intVal, err := strconv.Atoi(valueAsString)
+		if err != nil {
+			return nil, err
+		}
+		modifier.Value = intVal
+	case "int32":
+		intVal, err := strconv.ParseInt(valueAsString, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		modifier.Value = intVal
+	case "int64":
+		intVal, err := strconv.ParseInt(valueAsString, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		modifier.Value = intVal
+	default:
+		return nil, &UnsupportedTypeSpecifiedError{receivedType: fmt.Sprintf("%T", modifier.Value)}
+	}
+
 	return modifier, nil
 }
 
@@ -68,10 +104,11 @@ func (ims *interactionModifiers) modifyStatusCode() (bool, int) {
 	for _, m := range ims.Modifiers() {
 		if m.Path == "$.status" {
 			if m.Attempt == nil || *m.Attempt == int(atomic.LoadInt32(&ims.interaction.requestCount)) {
-				code, err := strconv.Atoi(m.Value)
-				if err == nil {
-					return true, code
+				code, ok := m.Value.(int)
+				if !ok {
+					return false, 0
 				}
+				return true, code
 			}
 		}
 	}

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -219,7 +219,7 @@ func (a *api) interactionsWaitHandler(res http.ResponseWriter, req *http.Request
 }
 
 func (a *api) indexHandler(res http.ResponseWriter, req *http.Request) {
-	log.Infof("proxying %s", req.URL.Path)
+	log.Infof("proxying %s %s", req.Method, req.URL.Path)
 
 	mediaType, err := parseMediaTypeHeader(req.Header)
 	if err != nil {
@@ -258,6 +258,13 @@ func (a *api) indexHandler(res http.ResponseWriter, req *http.Request) {
 		httpresponse.Errorf(res, http.StatusInternalServerError, "unable to read requestDocument data. %s", err.Error())
 		return
 	}
+	h := make(map[string]interface{})
+	for headerName, headerValues := range req.Header {
+		for _, headerValue := range headerValues {
+			h[headerName] = headerValue
+		}
+	}
+	request["headers"] = h
 
 	unmatched := make(map[string][]string)
 	matched := make([]*interaction, 0)

--- a/internal/app/proxy_stage_test.go
+++ b/internal/app/proxy_stage_test.go
@@ -19,20 +19,21 @@ import (
 )
 
 type ProxyStage struct {
-	t                   *testing.T
-	pact                *dsl.Pact
-	proxy               *pactproxy.PactProxy
-	nameConstraintValue string
-	bodyConstraintValue string
-	pactResult          error
-	pactName            string
-	requestsToSend      int32
-	requestsSent        int32
-	responses           []*http.Response
-	responseBodies      [][]byte
-	modifiedStatusCode  int
-	modifiedAttempt     *int
-	modifiedBody        map[string]interface{}
+	t                     *testing.T
+	pact                  *dsl.Pact
+	proxy                 *pactproxy.PactProxy
+	contentTypeConstraint string
+	nameConstraintValue   string
+	bodyConstraintValue   string
+	pactResult            error
+	pactName              string
+	requestsToSend        int32
+	requestsSent          int32
+	responses             []*http.Response
+	responseBodies        [][]byte
+	modifiedStatusCode    int
+	modifiedAttempt       *int
+	modifiedBody          map[string]interface{}
 }
 
 var largeString = strings.Repeat("long_string123BBmmF8BYezrBhCROOCRJfeH5k69hMKXH77TSvwF5GHUZFnbh1dsZ3d90HeR0jUIOovJJVS508uI17djeLFFSb7", 440)
@@ -238,6 +239,11 @@ func (s *ProxyStage) a_name_constraint_is_added(name string) *ProxyStage {
 	return s
 }
 
+func (s *ProxyStage) a_content_type_constraint_is_added(value string) *ProxyStage {
+	s.contentTypeConstraint = value
+	return s
+}
+
 func (s *ProxyStage) a_body_constraint_is_added(name string) *ProxyStage {
 	s.bodyConstraintValue = name
 	return s
@@ -288,6 +294,10 @@ func (s *ProxyStage) n_requests_are_sent_using_the_body_and_content_type(n int, 
 
 		if s.nameConstraintValue != "" {
 			i.AddConstraint("$.body.name", s.nameConstraintValue)
+		}
+
+		if s.contentTypeConstraint != "" {
+			i.AddConstraint("$.headers[\"Content-Type\"]", s.contentTypeConstraint)
 		}
 
 		if s.bodyConstraintValue != "" {

--- a/internal/app/proxy_stage_test.go
+++ b/internal/app/proxy_stage_test.go
@@ -32,7 +32,7 @@ type ProxyStage struct {
 	responseBodies      [][]byte
 	modifiedStatusCode  int
 	modifiedAttempt     *int
-	modifiedBody        map[string]string
+	modifiedBody        map[string]interface{}
 }
 
 var largeString = strings.Repeat("long_string123BBmmF8BYezrBhCROOCRJfeH5k69hMKXH77TSvwF5GHUZFnbh1dsZ3d90HeR0jUIOovJJVS508uI17djeLFFSb7", 440)
@@ -48,7 +48,7 @@ func NewProxyStage(t *testing.T) (*ProxyStage, *ProxyStage, *ProxyStage) {
 		t:            t,
 		proxy:        proxy,
 		pact:         pact,
-		modifiedBody: make(map[string]string),
+		modifiedBody: make(map[string]interface{}),
 		pactName:     "pact-" + strconv.FormatInt(time.Now().UnixMilli(), 10),
 	}
 
@@ -99,6 +99,24 @@ func (s *ProxyStage) a_pact_that_allows_any_names() *ProxyStage {
 			Status:  200,
 			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 			Body:    map[string]string{"name": "any"},
+		})
+	return s
+}
+
+func (s *ProxyStage) a_pact_that_allows_any_age() *ProxyStage {
+	s.pact.
+		AddInteraction().
+		UponReceiving(s.pactName).
+		WithRequest(dsl.Request{
+			Method:  "POST",
+			Path:    dsl.String("/users"),
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Body:    dsl.MapMatcher{"age": dsl.Integer()},
+		}).
+		WillRespondWith(dsl.Response{
+			Status:  200,
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Body:    map[string]int64{"age": 100},
 		})
 	return s
 }
@@ -230,7 +248,7 @@ func (s *ProxyStage) a_modified_response_status_of_(statusCode int) *ProxyStage 
 	return s
 }
 
-func (s *ProxyStage) a_modified_response_body_of_(path, value string) *ProxyStage {
+func (s *ProxyStage) a_modified_response_body_of_(path string, value interface{}) *ProxyStage {
 	s.modifiedBody[path] = value
 	return s
 }
@@ -253,6 +271,10 @@ func (s *ProxyStage) a_request_is_sent_using_the_name(name string) {
 
 func (s *ProxyStage) n_requests_are_sent_using_the_name(n int, name string) {
 	s.n_requests_are_sent_using_the_body(n, fmt.Sprintf(`{"name":"%s"}`, name))
+}
+
+func (s *ProxyStage) n_requests_are_sent_using_the_age(n int, age int64) {
+	s.n_requests_are_sent_using_the_body(n, fmt.Sprintf(`{"age": %d}`, age))
 }
 
 func (s *ProxyStage) n_requests_are_sent_using_the_body(n int, body string) {
@@ -408,6 +430,23 @@ func (s *ProxyStage) the_nth_response_name_is_(n int, name string) *ProxyStage {
 
 	if body["name"] != name {
 		s.t.Fatalf("Expected name on attempt %d,: %s, got: %s", n, name, body["name"])
+	}
+
+	return s
+}
+
+func (s *ProxyStage) the_nth_response_age_is_(n int, age int64) *ProxyStage {
+	if len(s.responses) < n {
+		s.t.Fatalf("Expected at least %d responses, got %d", n, len(s.responses))
+	}
+
+	var body map[string]int64
+	if err := json.Unmarshal(s.responseBodies[n-1], &body); err != nil {
+		s.t.Fatalf("unable to parse response body, %v", err)
+	}
+
+	if body["age"] != age {
+		s.t.Fatalf("Expected name on attempt %d,: %d, got: %d", n, age, body["age"])
 	}
 
 	return s

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -78,6 +78,35 @@ func TestConstraintDoesntMatch(t *testing.T) {
 		pact_verification_is_not_successful()
 }
 
+func TestConstraintHeaderMatch(t *testing.T) {
+	given, when, then := NewProxyStage(t)
+
+	given.
+		a_pact_that_allows_any_names().and().
+		a_content_type_constraint_is_added("application/json")
+
+	when.
+		a_request_is_sent_using_the_name("sam")
+
+	then.
+		pact_verification_is_successful().and().
+		pact_can_be_generated()
+}
+
+func TestConstraintHeaderDoesntMatch(t *testing.T) {
+	given, when, then := NewProxyStage(t)
+
+	given.
+		a_pact_that_allows_any_names().and().
+		a_content_type_constraint_is_added("text/plain")
+
+	when.
+		a_request_is_sent_using_the_name("sam")
+
+	then.
+		pact_verification_is_not_successful()
+}
+
 func TestWaitForPact(t *testing.T) {
 	given, when, then := NewProxyStage(t)
 
@@ -175,7 +204,7 @@ func TestModifiedBody_ForNRequests(t *testing.T) {
 		the_nth_response_name_is_(3, "any")
 }
 
-func TestModifiedBody_ForNRequestsa(t *testing.T) {
+func TestModifiedBody_With_Numeric_attributes_ForNRequests(t *testing.T) {
 	given, when, then := NewProxyStage(t)
 
 	given.

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -175,6 +175,25 @@ func TestModifiedBody_ForNRequests(t *testing.T) {
 		the_nth_response_name_is_(3, "any")
 }
 
+func TestModifiedBody_ForNRequestsa(t *testing.T) {
+	given, when, then := NewProxyStage(t)
+
+	given.
+		a_pact_that_allows_any_age().and().
+		a_modified_response_body_of_("$.body.age", 14).and().
+		a_modified_response_attempt_of(2)
+
+	when.
+		n_requests_are_sent_using_the_age(3, 100)
+
+	then.
+		pact_verification_is_successful().and().
+		n_responses_were_received(3).and().
+		the_nth_response_age_is_(1, 100).and().
+		the_nth_response_age_is_(2, 14).and().
+		the_nth_response_age_is_(3, 100)
+}
+
 func TestModifiedBodyWithFirstAndLastName_ForNRequests(t *testing.T) {
 	given, when, then := NewProxyStage(t)
 

--- a/pkg/pactproxy/pactproxy.go
+++ b/pkg/pactproxy/pactproxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -54,11 +55,12 @@ func (p *PactProxy) addConstraint(interaction, pactPath, value string) {
 	}
 }
 
-func (p *PactProxy) addModifier(interaction, path string, value interface{}, attempt *int) {
+func (p *PactProxy) addModifier(interaction, path string, value interface{}, valueType string, attempt *int) {
 	body := map[string]interface{}{
 		"interaction": interaction,
 		"path":        path,
 		"value":       value,
+		"type":        valueType,
 	}
 	if attempt != nil {
 		body["attempt"] = attempt
@@ -146,7 +148,12 @@ func (s InteractionSetup) AddConstraint(path, value string) InteractionSetup {
 }
 
 func (s InteractionSetup) AddModifier(path string, value interface{}, attempt *int) InteractionSetup {
-	s.pactProxy.addModifier(s.interaction, path, value, attempt)
+	s.pactProxy.addModifier(s.interaction, path, value, fmt.Sprintf("%T", value), attempt)
+	return s
+}
+
+func (s InteractionSetup) AddModifierAsType(path string, value interface{}, valueType string, attempt *int) InteractionSetup {
+	s.pactProxy.addModifier(s.interaction, path, value, valueType, attempt)
 	return s
 }
 

--- a/pkg/pactproxy/pactproxy.go
+++ b/pkg/pactproxy/pactproxy.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -55,12 +54,11 @@ func (p *PactProxy) addConstraint(interaction, pactPath, value string) {
 	}
 }
 
-func (p *PactProxy) addModifier(interaction, path string, value interface{}, valueType string, attempt *int) {
+func (p *PactProxy) addModifier(interaction, path string, value interface{}, attempt *int) {
 	body := map[string]interface{}{
 		"interaction": interaction,
 		"path":        path,
 		"value":       value,
-		"type":        valueType,
 	}
 	if attempt != nil {
 		body["attempt"] = attempt
@@ -148,12 +146,7 @@ func (s InteractionSetup) AddConstraint(path, value string) InteractionSetup {
 }
 
 func (s InteractionSetup) AddModifier(path string, value interface{}, attempt *int) InteractionSetup {
-	s.pactProxy.addModifier(s.interaction, path, value, fmt.Sprintf("%T", value), attempt)
-	return s
-}
-
-func (s InteractionSetup) AddModifierAsType(path string, value interface{}, valueType string, attempt *int) InteractionSetup {
-	s.pactProxy.addModifier(s.interaction, path, value, valueType, attempt)
+	s.pactProxy.addModifier(s.interaction, path, value, attempt)
 	return s
 }
 


### PR DESCRIPTION
This PR contains:
- update the type of `Value` of `interactionModifier` to cater for all types rather than only strings. 
- enable headers for constraints. 
