### PR TITLE
Refactor interaction mutex to be simpler and more consistent

### DIFF
--- a/internal/app/pactproxy/interaction_test.go
+++ b/internal/app/pactproxy/interaction_test.go
@@ -2,9 +2,10 @@ package pactproxy
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestLoadInteractionPlainTextConstraints(t *testing.T) {
@@ -104,18 +105,17 @@ func TestLoadInteractionPlainTextConstraints(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadInteraction(tt.interaction, "alias")
+			interaction, err := LoadInteraction(tt.interaction, "alias")
 
 			require.Equalf(t, tt.wantErr, err != nil, "error %v", err)
 
-			var gotConstraint interactionConstraint
-			got.constraints.Range(func(key, value interface{}) bool {
-				var present bool
-				gotConstraint, present = value.(interactionConstraint)
-				return present
-			})
+			var foundConstraint interactionConstraint
+			for _, constraint := range interaction.constraints {
+				foundConstraint = constraint
+				break
+			}
 
-			assert.EqualValues(t, tt.wantConstraint, gotConstraint)
+			assert.EqualValues(t, tt.wantConstraint, foundConstraint)
 		})
 	}
 }
@@ -239,18 +239,17 @@ func TestV3MatchingRulesLeadToCorrectConstraints(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadInteraction(tt.interaction, "alias")
+			interaction, err := LoadInteraction(tt.interaction, "alias")
 
 			require.Equalf(t, tt.wantErr, err != nil, "error %v", err)
 
-			var gotConstraint interactionConstraint
-			got.constraints.Range(func(key, value interface{}) bool {
-				var present bool
-				gotConstraint, present = value.(interactionConstraint)
-				return present
-			})
+			var foundConstraint interactionConstraint
+			for _, constraint := range interaction.constraints {
+				foundConstraint = constraint
+				break
+			}
 
-			assert.EqualValues(t, tt.wantConstraint, gotConstraint)
+			assert.EqualValues(t, tt.wantConstraint, foundConstraint)
 		})
 	}
 }

--- a/internal/app/pactproxy/proxy_test.go
+++ b/internal/app/pactproxy/proxy_test.go
@@ -46,10 +46,7 @@ func TestInteractionsWaitHandler(t *testing.T) {
 			name: "timing out existing interaction",
 			interactions: func() *Interactions {
 				interactions := Interactions{}
-				interactions.Store(&interaction{
-					Alias:       "existing",
-					Description: "Existing",
-				})
+				interactions.Store(newInteraction("existing"))
 				return &interactions
 			}(),
 			req: func() *http.Request {
@@ -71,4 +68,17 @@ func TestInteractionsWaitHandler(t *testing.T) {
 			r.Equal(tt.code, rec.Code)
 		})
 	}
+}
+
+func newInteraction(alias string) *interaction {
+	i := &interaction{
+		Alias:       alias,
+		Description: alias,
+		constraints: map[string]interactionConstraint{},
+	}
+	i.Modifiers = &interactionModifiers{
+		interaction: i,
+		modifiers:   map[string]*interactionModifier{},
+	}
+	return i
 }


### PR DESCRIPTION
The interaction struct contains a mix of `sync.Map` and `atomic.Value`.

Related to: https://github.com/form3tech-oss/pact-proxy/pull/28

In preparation for adding another element which also requires locking, for read / write operations, refactor to use a shared `sync.RWMutex`.

Note planned PR also requires to be able to marshal the interaction object into a JSON response.  Replacing these elements with simple golang constructs makes this simpler, avoiding the need to copy into another response struct.