### PR TITLE
feat: add endpoint to get interactions

### DIFF
--- a/internal/app/concurrent_proxy_stage_test.go
+++ b/internal/app/concurrent_proxy_stage_test.go
@@ -35,7 +35,7 @@ type ConcurrentProxyStage struct {
 }
 
 func NewConcurrentProxyStage(t *testing.T) (*ConcurrentProxyStage, *ConcurrentProxyStage, *ConcurrentProxyStage) {
-	proxy, err := setupAndWaitForProxy()
+	proxy, err := setupAndWaitForProxy(ProxyConfig{})
 	if err != nil {
 		t.Logf("Error setting up proxy: %v", err)
 		t.Fail()

--- a/internal/app/configuration/api.go
+++ b/internal/app/configuration/api.go
@@ -40,7 +40,7 @@ func postProxiesHandler(c echo.Context) error {
 	if err != nil {
 		return c.JSON(
 			http.StatusBadRequest,
-			httpresponse.Errorf("unable to parse interactionConstraint from data. %s", err.Error()),
+			httpresponse.Errorf("unable to parse proxyConfig from data: %s", err.Error()),
 		)
 	}
 

--- a/internal/app/pactproxy/interaction.go
+++ b/internal/app/pactproxy/interaction.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -40,22 +39,22 @@ func (m *regexPathMatcher) match(val string) bool {
 	return m.val.MatchString(val)
 }
 
-type interaction struct {
+type Interaction struct {
 	mu             sync.RWMutex
 	pathMatcher    pathMatcher
 	Method         string                           `json:"method"`
 	Alias          string                           `json:"alias"`
 	Description    string                           `json:"description"`
-	Definition     map[string]interface{}           `json:"definition"`
-	Constraints    map[string]interactionConstraint `json:"constraints"`
-	Modifiers      *interactionModifiers            `json:"modifiers"`
 	RequestCount   int                              `json:"request_count"`
 	RequestHistory []requestDocument                `json:"request_history,omitempty"`
-	lastRequest    requestDocument                  `json:"-"`
+	LastRequest    requestDocument                  `json:"last_request"`
+	definition     map[string]interface{}           `json:"-"`
+	constraints    map[string]interactionConstraint `json:"-"`
+	modifiers      interactionModifiers             `json:"-"`
 	recordHistory  bool                             `json:"-"`
 }
 
-func LoadInteraction(data []byte, alias string) (*interaction, error) {
+func LoadInteraction(data []byte, alias string) (*Interaction, error) {
 	definition := make(map[string]interface{})
 	err := json.Unmarshal(data, &definition)
 	if err != nil {
@@ -91,16 +90,16 @@ func LoadInteraction(data []byte, alias string) (*interaction, error) {
 	}
 	propertiesWithMatchingRule := getBodyPropertiesWithMatchingRules(matchingRules)
 
-	interaction := &interaction{
+	interaction := &Interaction{
 		pathMatcher: matcher,
 		Method:      request["method"].(string),
 		Alias:       alias,
-		Definition:  definition,
+		definition:  definition,
 		Description: description,
-		Constraints: map[string]interactionConstraint{},
+		constraints: map[string]interactionConstraint{},
 	}
 
-	interaction.Modifiers = &interactionModifiers{
+	interaction.modifiers = interactionModifiers{
 		interaction: interaction,
 		modifiers:   map[string]*interactionModifier{},
 	}
@@ -262,7 +261,7 @@ func parseMediaType(request map[string]interface{}) (string, error) {
 
 // This function adds constraints for all the fields in the JSON request body which do not
 // have a corresponding matching rule
-func (i *interaction) addJSONConstraintsFromPact(path string, matchingRules map[string]bool, values map[string]interface{}) {
+func (i *Interaction) addJSONConstraintsFromPact(path string, matchingRules map[string]bool, values map[string]interface{}) {
 	for k, v := range values {
 		switch val := v.(type) {
 		case map[string]interface{}:
@@ -285,7 +284,7 @@ func (i *interaction) addJSONConstraintsFromPact(path string, matchingRules map[
 
 // This function adds constraints for the entire plain text request body if
 // it doesn't have a corresponding matching rule
-func (i *interaction) addTextConstraintsFromPact(matchingRules map[string]bool, constraint string) {
+func (i *Interaction) addTextConstraintsFromPact(matchingRules map[string]bool, constraint string) {
 	if _, present := matchingRules["$.body"]; !present {
 		i.AddConstraint(interactionConstraint{
 			Path:   "$.body",
@@ -294,17 +293,17 @@ func (i *interaction) addTextConstraintsFromPact(matchingRules map[string]bool, 
 		})
 	}
 }
-func (i *interaction) Match(path, method string) bool {
+func (i *Interaction) Match(path, method string) bool {
 	return method == i.Method && i.pathMatcher.match(path)
 }
 
-func (i *interaction) AddConstraint(constraint interactionConstraint) {
+func (i *Interaction) AddConstraint(constraint interactionConstraint) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	i.Constraints[constraint.Key()] = constraint
+	i.constraints[constraint.Key()] = constraint
 }
 
-func (i *interaction) loadValuesFromSource(constraint interactionConstraint, interactions *Interactions) ([]interface{}, error) {
+func (i *Interaction) loadValuesFromSource(constraint interactionConstraint, interactions *Interactions) ([]interface{}, error) {
 	values := append([]interface{}(nil), constraint.Values...)
 	sourceInteraction, ok := interactions.Load(constraint.Source)
 	if !ok {
@@ -312,26 +311,26 @@ func (i *interaction) loadValuesFromSource(constraint interactionConstraint, int
 	}
 
 	i.mu.RLock()
-	sourceRequest := sourceInteraction.lastRequest
+	sourceRequest := sourceInteraction.LastRequest
 	i.mu.RUnlock()
-	if len(sourceRequest) == 0 {
+	if sourceRequest == nil {
 		return nil, errors.Errorf("source interaction '%s' as no requests", constraint.Source)
 	}
 
 	for i, v := range constraint.Values {
-		values[i], _ = jsonpath.Get(v.(string), map[string]interface{}(sourceRequest))
+		values[i], _ = jsonpath.Get(v.(string), sourceRequest)
 	}
 
 	return values, nil
 }
 
-func (i *interaction) EvaluateConstrains(request requestDocument, interactions *Interactions) (bool, []string) {
+func (i *Interaction) EvaluateConstrains(request requestDocument, interactions *Interactions) (bool, []string) {
 	result := true
 	violations := make([]string, 0)
 
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	for _, constraint := range i.Constraints {
+	for _, constraint := range i.constraints {
 		values := constraint.Values
 		if constraint.Source != "" {
 			var err error
@@ -366,10 +365,10 @@ func (i *interaction) EvaluateConstrains(request requestDocument, interactions *
 	return result, violations
 }
 
-func (i *interaction) StoreRequest(request requestDocument) {
+func (i *Interaction) StoreRequest(request requestDocument) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	i.lastRequest = request
+	i.LastRequest = request
 	i.RequestCount++
 
 	if i.recordHistory {
@@ -377,11 +376,11 @@ func (i *interaction) StoreRequest(request requestDocument) {
 	}
 }
 
-func (i *interaction) HasRequests(count int) bool {
+func (i *Interaction) HasRequests(count int) bool {
 	return i.getRequestCount() >= count
 }
 
-func (i *interaction) getRequestCount() int {
+func (i *Interaction) getRequestCount() int {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return i.RequestCount

--- a/internal/app/pactproxy/interaction_test.go
+++ b/internal/app/pactproxy/interaction_test.go
@@ -110,7 +110,7 @@ func TestLoadInteractionPlainTextConstraints(t *testing.T) {
 			require.Equalf(t, tt.wantErr, err != nil, "error %v", err)
 
 			var foundConstraint interactionConstraint
-			for _, constraint := range interaction.constraints {
+			for _, constraint := range interaction.Constraints {
 				foundConstraint = constraint
 				break
 			}
@@ -244,7 +244,7 @@ func TestV3MatchingRulesLeadToCorrectConstraints(t *testing.T) {
 			require.Equalf(t, tt.wantErr, err != nil, "error %v", err)
 
 			var foundConstraint interactionConstraint
-			for _, constraint := range interaction.constraints {
+			for _, constraint := range interaction.Constraints {
 				foundConstraint = constraint
 				break
 			}

--- a/internal/app/pactproxy/interaction_test.go
+++ b/internal/app/pactproxy/interaction_test.go
@@ -110,7 +110,7 @@ func TestLoadInteractionPlainTextConstraints(t *testing.T) {
 			require.Equalf(t, tt.wantErr, err != nil, "error %v", err)
 
 			var foundConstraint interactionConstraint
-			for _, constraint := range interaction.Constraints {
+			for _, constraint := range interaction.constraints {
 				foundConstraint = constraint
 				break
 			}
@@ -244,7 +244,7 @@ func TestV3MatchingRulesLeadToCorrectConstraints(t *testing.T) {
 			require.Equalf(t, tt.wantErr, err != nil, "error %v", err)
 
 			var foundConstraint interactionConstraint
-			for _, constraint := range interaction.Constraints {
+			for _, constraint := range interaction.constraints {
 				foundConstraint = constraint
 				break
 			}

--- a/internal/app/pactproxy/interactions.go
+++ b/internal/app/pactproxy/interactions.go
@@ -8,7 +8,7 @@ type Interactions struct {
 	interactions sync.Map
 }
 
-func (i *Interactions) Store(interaction *interaction) {
+func (i *Interactions) Store(interaction *Interaction) {
 	i.interactions.Store(interaction.Description, interaction)
 	if interaction.Alias != "" {
 		i.interactions.Store(interaction.Alias, interaction)
@@ -22,20 +22,20 @@ func (i *Interactions) Clear() {
 	})
 }
 
-func (i *Interactions) Load(key string) (*interaction, bool) {
+func (i *Interactions) Load(key string) (*Interaction, bool) {
 	result, ok := i.interactions.Load(key)
 	if !ok {
 		return nil, false
 	}
-	return result.(*interaction), true
+	return result.(*Interaction), true
 }
 
-func (i *Interactions) FindAll(path, method string) ([]*interaction, bool) {
-	interactions := make(map[string]*interaction)
-	var result []*interaction
+func (i *Interactions) FindAll(path, method string) ([]*Interaction, bool) {
+	interactions := make(map[string]*Interaction)
+	var result []*Interaction
 	i.interactions.Range(func(_, v interface{}) bool {
-		if v.(*interaction).Match(path, method) {
-			i := v.(*interaction)
+		if v.(*Interaction).Match(path, method) {
+			i := v.(*Interaction)
 			interactions[i.Description] = i
 		}
 		return true
@@ -48,10 +48,10 @@ func (i *Interactions) FindAll(path, method string) ([]*interaction, bool) {
 	return result, len(result) > 0
 }
 
-func (i *Interactions) All() []*interaction {
-	var interactions []*interaction
+func (i *Interactions) All() []*Interaction {
+	var interactions []*Interaction
 	i.interactions.Range(func(_, v interface{}) bool {
-		interactions = append(interactions, v.(*interaction))
+		interactions = append(interactions, v.(*Interaction))
 		return true
 	})
 	return interactions
@@ -60,7 +60,7 @@ func (i *Interactions) All() []*interaction {
 func (i *Interactions) AllHaveRequests() bool {
 	result := true
 	i.interactions.Range(func(_, v interface{}) bool {
-		if !v.(*interaction).HasRequests(1) {
+		if !v.(*Interaction).HasRequests(1) {
 			result = false
 			return false
 		}

--- a/internal/app/pactproxy/modifier.go
+++ b/internal/app/pactproxy/modifier.go
@@ -16,7 +16,7 @@ type interactionModifier struct {
 }
 
 type interactionModifiers struct {
-	interaction *interaction
+	interaction *Interaction
 	modifiers   map[string]*interactionModifier
 }
 

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -26,6 +26,7 @@ type Config struct {
 	Proxies       []url.URL     `env:"PROXIES,delimiter=;"` // List of URL to serve pact-proxy on, e.g. http://localhost:8080;http://localhost:8081
 	WaitDelay     time.Duration `env:"WAIT_DELAY"`          // Default Delay for WaitForInteractions endpoint
 	WaitDuration  time.Duration `env:"WAIT_DURATION"`       // Default Duration for WaitForInteractions endpoint
+	RecordHistory bool          `env:"RECORD_HISTORY`
 	Target        url.URL       // Do not load Target from env, we set this for each value from Proxies
 }
 
@@ -54,12 +55,13 @@ func StartProxy(e *echo.Echo, config *Config) {
 
 	// Create these once at startup, thay are shared by all server threads
 	a := api{
-		target:       &config.Target,
-		proxy:        httputil.NewSingleHostReverseProxy(&config.Target),
-		interactions: &Interactions{},
-		notify:       NewNotify(),
-		delay:        config.WaitDelay,
-		duration:     config.WaitDuration,
+		target:        &config.Target,
+		proxy:         httputil.NewSingleHostReverseProxy(&config.Target),
+		interactions:  &Interactions{},
+		notify:        NewNotify(),
+		delay:         config.WaitDelay,
+		duration:      config.WaitDuration,
+		recordHistory: config.RecordHistory,
 	}
 	if a.delay == 0 {
 		a.delay = defaultDelay

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -26,7 +26,7 @@ type Config struct {
 	Proxies       []url.URL     `env:"PROXIES,delimiter=;"` // List of URL to serve pact-proxy on, e.g. http://localhost:8080;http://localhost:8081
 	WaitDelay     time.Duration `env:"WAIT_DELAY"`          // Default Delay for WaitForInteractions endpoint
 	WaitDuration  time.Duration `env:"WAIT_DURATION"`       // Default Duration for WaitForInteractions endpoint
-	RecordHistory bool          `env:"RECORD_HISTORY`
+	RecordHistory bool          `env:"RECORD_HISTORY"`
 	Target        url.URL       // Do not load Target from env, we set this for each value from Proxies
 }
 
@@ -52,7 +52,6 @@ func (a *api) ProxyRequest(c echo.Context) error {
 }
 
 func StartProxy(e *echo.Echo, config *Config) {
-
 	// Create these once at startup, thay are shared by all server threads
 	a := api{
 		target:        &config.Target,
@@ -83,7 +82,7 @@ func StartProxy(e *echo.Echo, config *Config) {
 	e.POST("/interactions", a.interactionsPostHandler)
 	e.DELETE("/interactions", a.interactionsDeleteHandler)
 
-	e.GET("/interactions/:alias", a.interactionsGetHandler)
+	e.GET("/interactions/details/:alias", a.interactionsGetHandler)
 	e.GET("/interactions/wait", a.interactionsWaitHandler)
 
 	e.Any("/*", a.indexHandler)
@@ -128,7 +127,7 @@ func (a *api) interactionsModifiersHandler(c echo.Context) error {
 	}
 
 	log.Infof("adding modifier to interaction '%s'", interaction.Description)
-	interaction.Modifiers.AddModifier(modifier)
+	interaction.modifiers.AddModifier(modifier)
 
 	return c.NoContent(http.StatusOK)
 }
@@ -287,7 +286,7 @@ func (a *api) indexHandler(c echo.Context) error {
 	request["headers"] = h
 
 	unmatched := make(map[string][]string)
-	matched := make([]*interaction, 0)
+	matched := make([]*Interaction, 0)
 	for _, interaction := range allInteractions {
 		ok, info := interaction.EvaluateConstrains(request, a.interactions)
 		if ok {

--- a/internal/app/pactproxy/proxy_test.go
+++ b/internal/app/pactproxy/proxy_test.go
@@ -71,13 +71,13 @@ func TestInteractionsWaitHandler(t *testing.T) {
 	}
 }
 
-func newInteraction(alias string) *interaction {
-	i := &interaction{
+func newInteraction(alias string) *Interaction {
+	i := &Interaction{
 		Alias:       alias,
 		Description: alias,
-		Constraints: map[string]interactionConstraint{},
+		constraints: map[string]interactionConstraint{},
 	}
-	i.Modifiers = &interactionModifiers{
+	i.modifiers = interactionModifiers{
 		interaction: i,
 		modifiers:   map[string]*interactionModifier{},
 	}
@@ -113,7 +113,7 @@ func TestInteractionsGetHandler(t *testing.T) {
 				return &interactions
 			}(),
 			code: http.StatusOK,
-			body: `{"method":"","alias":"test","description":"test","definition":null,"constraints":{},"modifiers":{},"request_count":1}`,
+			body: `{"method":"","alias":"test","description":"test","request_count":1,"last_request":{"body":{"foo":"bar"},"path":"/testpath"}}`,
 		},
 		{
 			name: "interaction found - with request history",
@@ -130,7 +130,7 @@ func TestInteractionsGetHandler(t *testing.T) {
 				return &interactions
 			}(),
 			code: http.StatusOK,
-			body: `{"method":"","alias":"test","description":"test","definition":null,"constraints":{},"modifiers":{},"request_count":1,"request_history":[{"body":{"foo":"bar"},"path":"/testpath"}]}`,
+			body: `{"method":"","alias":"test","description":"test","request_count":1,"request_history":[{"body":{"foo":"bar"},"path":"/testpath"}],"last_request":{"body":{"foo":"bar"},"path":"/testpath"}}`,
 		},
 		{
 			name:         "interaction not found",

--- a/internal/app/pactproxy/request.go
+++ b/internal/app/pactproxy/request.go
@@ -15,7 +15,7 @@ func ParseJSONRequest(data []byte, url *url.URL) (requestDocument, error) {
 	if len(data) > 0 {
 		err := json.Unmarshal(data, &body)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to parse requestDocument body")
+			return nil, errors.Wrap(err, "unable to parse RequestDocument body")
 		}
 	}
 	queryValues := parseQueryValues(url)

--- a/internal/app/pactproxy/response_modification_writer.go
+++ b/internal/app/pactproxy/response_modification_writer.go
@@ -8,7 +8,7 @@ import (
 
 type ResponseModificationWriter struct {
 	res              http.ResponseWriter
-	interactions     []*interaction
+	interactions     []*Interaction
 	originalResponse []byte
 	statusCode       int
 }
@@ -30,7 +30,7 @@ func (m *ResponseModificationWriter) Write(b []byte) (int, error) {
 
 	var modifiedBody []byte
 	for _, i := range m.interactions {
-		modifiedBody, err = i.Modifiers.modifyBody(m.originalResponse)
+		modifiedBody, err = i.modifiers.modifyBody(m.originalResponse)
 		if err != nil {
 			return 0, err
 		}
@@ -52,7 +52,7 @@ func (m *ResponseModificationWriter) Write(b []byte) (int, error) {
 func (m *ResponseModificationWriter) WriteHeader(statusCode int) {
 	m.statusCode = statusCode
 	for _, i := range m.interactions {
-		ok, code := i.Modifiers.modifyStatusCode()
+		ok, code := i.modifiers.modifyStatusCode()
 		if ok {
 			m.statusCode = code
 			break

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -377,3 +377,20 @@ func TestEmptyContentTypeDefaultsToPlainText(t *testing.T) {
 		the_response_is_(http.StatusOK).and().
 		the_response_body_to_plain_text_request_is_correct()
 }
+
+func TestGetInteractionDetailsAndHistory(t *testing.T) {
+	config := ProxyConfig{RecordHistory: true}
+	given, when, then := NewProxyStageWithConfig(t, config)
+
+	given.
+		the_record_history_config_option_is_enabled().and().
+		a_pact_that_allows_any_names()
+
+	when.
+		multiple_requests_are_sent_using_the_names("rod", "jane", "freddy")
+
+	then.
+		pact_verification_is_successful().and().
+		the_proxy_waits_for_all_requests().and().
+		the_proxy_returns_details_of_all_requests()
+}

--- a/internal/app/setup_test.go
+++ b/internal/app/setup_test.go
@@ -3,7 +3,6 @@ package app
 import (
 	"bytes"
 	"fmt"
-	"github.com/pact-foundation/pact-go/dsl"
 	"net/url"
 	"os"
 	"os/exec"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
 
 	"github.com/form3tech-oss/pact-proxy/internal/app/configuration"
 	"github.com/pact-foundation/pact-go/utils"

--- a/pkg/pactproxy/proxyconfig.go
+++ b/pkg/pactproxy/proxyconfig.go
@@ -18,6 +18,8 @@ type ProxyConfiguration struct {
 	url    string
 }
 
+type Config pactproxy.Config
+
 func Configuration(url string) *ProxyConfiguration {
 	return &ProxyConfiguration{
 		client: http.Client{
@@ -37,11 +39,14 @@ func (conf *ProxyConfiguration) SetupProxy(serverAddress, targetAddress string) 
 		return nil, errors.Wrap(err, "failed to parse target address")
 	}
 
-	config := &pactproxy.Config{
+	config := &Config{
 		ServerAddress: *serverURL,
 		Target:        *targetURL,
 	}
+	return conf.SetupProxyWithConfig(config)
+}
 
+func (conf *ProxyConfiguration) SetupProxyWithConfig(config *Config) (*PactProxy, error) {
 	content, err := json.Marshal(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal config")
@@ -65,6 +70,7 @@ func (conf *ProxyConfiguration) SetupProxy(serverAddress, targetAddress string) 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return nil, errors.New(string(responseBody))
 	}
+	serverAddress := config.ServerAddress.String()
 	return New(serverAddress), err
 }
 

--- a/pkg/pactproxy/types.go
+++ b/pkg/pactproxy/types.go
@@ -1,0 +1,19 @@
+package pactproxy
+
+import "encoding/json"
+
+type Interaction struct {
+	Alias          string                 `json:"alias"`
+	Description    string                 `json:"description"`
+	Definition     map[string]interface{} `json:"definition"`
+	Method         string                 `json:"method"`
+	RequestCount   int                    `json:"request_count"`
+	RequestHistory []RequestDocument      `json:"request_history,omitempty"`
+}
+
+type RequestDocument struct {
+	Headers map[string]string `json:"headers"`
+	Query   json.RawMessage   `json:"query"`
+	Body    json.RawMessage   `json:"body"`
+	Path    string            `json:"path"`
+}


### PR DESCRIPTION
Adds a new endpoint to get interaction details for a specified interaction.

If the `RECORD_HISTORY` option is set to true (via env config) then the proxy will additional record in memory the requests made for each interaction, and return it with the interaction details.

This allows us to capture details of the requests made in our integration tests.

Investment time project: https://github.com/form3tech/investment-time-project/issues/62

Co-authored-by: Kevin Intriago <kevin.intriago@form3.tech>