### PR TITLE
fix: handle multiple proxies

### DIFF
--- a/cmd/pact-proxy/main.go
+++ b/cmd/pact-proxy/main.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/form3tech-oss/pact-proxy/internal/app/configuration"
-	"github.com/form3tech-oss/pact-proxy/internal/app/pactproxy"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,8 +16,11 @@ func main() {
 		log.WithError(err).Fatal("unable to load configuration")
 	}
 	for _, proxy := range config.Proxies {
-		log.Infof("setting up proxy for %s", proxy)
-		if err := configuration.ConfigureProxy(pactproxy.Config{Target: proxy}); err != nil {
+		log.Infof("setting up proxy for %s", proxy.String())
+
+		proxyConfig := config
+		proxyConfig.Target = proxy
+		if err := configuration.ConfigureProxy(proxyConfig); err != nil {
 			panic(err)
 		}
 	}

--- a/internal/app/configuration/proxyconfig.go
+++ b/internal/app/configuration/proxyconfig.go
@@ -2,6 +2,8 @@ package configuration
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	"github.com/form3tech-oss/pact-proxy/internal/app/pactproxy"
 	"github.com/pkg/errors"
@@ -20,11 +22,23 @@ func NewFromEnv() (pactproxy.Config, error) {
 }
 
 func ConfigureProxy(config pactproxy.Config) error {
-	server, err := GetServer(&config.ServerAddress)
+	serverAddr, err := getServerAddr(config)
+	if err != nil {
+		return err
+	}
+
+	server, err := GetServer(serverAddr)
 	if err != nil {
 		return err
 	}
 
 	pactproxy.StartProxy(server, &config)
 	return err
+}
+
+func getServerAddr(config pactproxy.Config) (*url.URL, error) {
+	if config.ServerAddress.Host != "" {
+		return &config.ServerAddress, nil
+	}
+	return url.Parse(fmt.Sprintf("http://:%s", config.Target.Port()))
 }


### PR DESCRIPTION
This PR fixes the issue when running pact-proxy with multiple services in the `PROXIES` env variable.
This was broken in https://github.com/form3tech-oss/pact-proxy/commit/261f0eb3f9c940ec07d2ad32375448c1954e0cf7

Using this docker config:
 ```yaml
 pactproxy:
    image: xxx/pact-proxy:v0.3.0
    environment:
      - PROXIES=http://servicea:8105;http://serviceb:8106
```
Before:
```
time="2022-12-14T16:06:21Z" level=info msg="setting up proxy for {http   servicea:8105   %!s(bool=false)   }"
time="2022-12-14T16:06:21Z" level=info msg="setting up proxy for {http   serviceb:8106   %!s(bool=false)   }"
panic: proxy already running at
```

After:
```
time="2022-12-14T16:15:01Z" level=info msg="setting up proxy for http://servicea:8105"
time="2022-12-14T16:15:01Z" level=info msg="setting up proxy for http://serviceb:8106"
⇨ http server started on [::]:8106
⇨ http server started on [::]:8105
⇨ http server started on [::]:8080
```