### PR TITLE
fix: Listen on target port if server address is not configured

### DIFF
--- a/cmd/pact-proxy/main.go
+++ b/cmd/pact-proxy/main.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/form3tech-oss/pact-proxy/internal/app/configuration"
-	"github.com/form3tech-oss/pact-proxy/internal/app/pactproxy"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,8 +16,10 @@ func main() {
 		log.WithError(err).Fatal("unable to load configuration")
 	}
 	for _, proxy := range config.Proxies {
-		log.Infof("setting up proxy for %s", proxy)
-		if err := configuration.ConfigureProxy(pactproxy.Config{Target: proxy}); err != nil {
+		log.Infof("setting up proxy for %s", proxy.String())
+		config.Target = proxy
+		err := configuration.ConfigureProxy(config)
+		if err != nil {
 			panic(err)
 		}
 	}

--- a/internal/app/configuration/proxyconfig.go
+++ b/internal/app/configuration/proxyconfig.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/form3tech-oss/pact-proxy/internal/app/pactproxy"
 	"github.com/pkg/errors"
@@ -20,7 +21,15 @@ func NewFromEnv() (pactproxy.Config, error) {
 }
 
 func ConfigureProxy(config pactproxy.Config) error {
-	server, err := GetServer(&config.ServerAddress)
+	targetURL := config.Target
+
+	// If ServerAddress is not passed, listen on the target port
+	serverAddr := config.ServerAddress
+	if (serverAddr == url.URL{}) {
+		serverAddr = url.URL{Scheme: "http", Host: ":" + targetURL.Port()}
+	}
+
+	server, err := GetServer(&serverAddr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes a change in a previous PR that breaks some common use cases.

When SERVER_ADDRESS is not specified we should listen on the port(s) specified in PROXIES.