### PR TITLE
fix: request count race condition

### DIFF
--- a/internal/app/concurrent_proxy_test.go
+++ b/internal/app/concurrent_proxy_test.go
@@ -24,6 +24,22 @@ func TestConcurrentRequestsForDifferentModifiersHaveTheCorrectResponses(t *testi
 		all_the_address_responses_should_have_the_right_status_code()
 }
 
+func TestConcurrentRequestsWithAnAttemptModifierHaveTheCorrectResponses(t *testing.T) {
+	given, when, then := NewConcurrentProxyStage(t)
+
+	given.
+		a_pact_that_allows_any_names().and().
+		a_modified_name_status_code().and().
+		a_modified_name_response_attempt_of(1)
+
+	when.
+		x_concurrent_user_requests_per_second_are_made_for_y_seconds(2, 1*time.Second).and().
+		the_concurrent_requests_are_sent()
+
+	then.
+		all_the_user_responses_should_have_the_right_status_code()
+}
+
 func TestConcurrentRequestsWaitForAllPacts(t *testing.T) {
 	given, when, then := NewConcurrentProxyStage(t)
 

--- a/internal/app/pactproxy/interaction.go
+++ b/internal/app/pactproxy/interaction.go
@@ -365,7 +365,7 @@ func (i *Interaction) EvaluateConstrains(request requestDocument, interactions *
 	return result, violations
 }
 
-func (i *Interaction) StoreRequest(request requestDocument) {
+func (i *Interaction) StoreRequest(request requestDocument) int {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.LastRequest = request
@@ -374,6 +374,7 @@ func (i *Interaction) StoreRequest(request requestDocument) {
 	if i.recordHistory {
 		i.RequestHistory = append(i.RequestHistory, request)
 	}
+	return i.RequestCount
 }
 
 func (i *Interaction) HasRequests(count int) bool {

--- a/internal/app/pactproxy/modifier.go
+++ b/internal/app/pactproxy/modifier.go
@@ -40,9 +40,8 @@ func (ims *interactionModifiers) Modifiers() []*interactionModifier {
 	return result
 }
 
-func (ims *interactionModifiers) modifyBody(b []byte) ([]byte, error) {
+func (ims *interactionModifiers) modifyBody(b []byte, requestCount int) ([]byte, error) {
 	for _, m := range ims.Modifiers() {
-		requestCount := ims.interaction.getRequestCount()
 		if strings.HasPrefix(m.Path, "$.body.") {
 			if m.Attempt == nil || *m.Attempt == requestCount {
 				var err error
@@ -56,9 +55,8 @@ func (ims *interactionModifiers) modifyBody(b []byte) ([]byte, error) {
 	return b, nil
 }
 
-func (ims *interactionModifiers) modifyStatusCode() (bool, int) {
+func (ims *interactionModifiers) modifyStatusCode(requestCount int) (bool, int) {
 	for _, m := range ims.Modifiers() {
-		requestCount := ims.interaction.getRequestCount()
 		if m.Path == "$.status" {
 			if m.Attempt == nil || *m.Attempt == requestCount {
 				code, err := strconv.Atoi(fmt.Sprintf("%v", m.Value))


### PR DESCRIPTION
When handling simultaneous requests that affect the same interaction we get a race condition for the request count when applying any modifiers. This is because we increment and retrieve the request count for an interaction in different steps without a lock.

This PR fixes this issue by not relying on the request count that could have been modified by another request.