### PR TITLE
feat: support array-type request body [WIP]

### DIFF
--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -294,7 +294,7 @@ func (a *api) indexHandler(c echo.Context) error {
 	unmatched := make(map[string][]string)
 	matched := make([]*Interaction, 0)
 	for _, interaction := range allInteractions {
-		ok, info := interaction.EvaluateConstrains(request, a.interactions)
+		ok, info := interaction.EvaluateConstraints(request, a.interactions)
 		if ok {
 			interaction.StoreRequest(request)
 			matched = append(matched, interaction)

--- a/internal/app/pactproxy/request.go
+++ b/internal/app/pactproxy/request.go
@@ -11,14 +11,27 @@ import (
 type requestDocument map[string]interface{}
 
 func ParseJSONRequest(data []byte, url *url.URL) (requestDocument, error) {
+	queryValues := parseQueryValues(url)
+
 	body := make(map[string]interface{})
 	if len(data) > 0 {
 		err := json.Unmarshal(data, &body)
+
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to parse RequestDocument body")
+			// The request body may be an array
+			var arrayBody []interface{}
+			err = json.Unmarshal(data, &arrayBody)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to parse RequestDocument body")
+			}
+
+			return map[string]interface{}{
+				"path":  url.Path,
+				"body":  arrayBody,
+				"query": queryValues,
+			}, nil
 		}
 	}
-	queryValues := parseQueryValues(url)
 
 	return map[string]interface{}{
 		"path":  url.Path,


### PR DESCRIPTION
Currently `pact-proxy` does not support array-type request body. If an array-type request body is specified in an interaction with request `Content-Type` header set to `application/json`, `pact-proxy` returns an error saying `media type is application/json but body is not json`. However, an array should be a valid JSON. 

This pull request should address the above issue, thus `pact-proxy` can support interactions with array-type request bodies.