### PR TITLE
feat: Pass request to pact mock server if no interaction found

### DIFF
--- a/internal/app/configuration/proxyconfig.go
+++ b/internal/app/configuration/proxyconfig.go
@@ -13,9 +13,6 @@ func NewFromEnv() (pactproxy.Config, error) {
 	ctx := context.Background()
 
 	var config pactproxy.Config
-
-	config.RejectUnrecognizedInteractions = true
-
 	err := envconfig.Process(ctx, &config)
 	if err != nil {
 		return config, errors.Wrap(err, "process env config")

--- a/internal/app/configuration/proxyconfig.go
+++ b/internal/app/configuration/proxyconfig.go
@@ -13,6 +13,9 @@ func NewFromEnv() (pactproxy.Config, error) {
 	ctx := context.Background()
 
 	var config pactproxy.Config
+
+	config.RejectUnrecognizedInteractions = true
+
 	err := envconfig.Process(ctx, &config)
 	if err != nil {
 		return config, errors.Wrap(err, "process env config")

--- a/internal/app/configuration/proxyconfig_test.go
+++ b/internal/app/configuration/proxyconfig_test.go
@@ -183,6 +183,47 @@ func TestConfigureProxy_MTLS(t *testing.T) {
 	}
 }
 
+func TestProxyConfig_RejectUnrecognizedInteractions(t *testing.T) {
+	os.Clearenv()
+	expectedDefaultValue := true
+
+	config, err := NewFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, expectedDefaultValue, config.RejectUnrecognizedInteractions) // If no env var is specified it should default to true
+
+	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "false")
+	config, err = NewFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, false, config.RejectUnrecognizedInteractions)
+
+	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "true")
+	config, err = NewFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, true, config.RejectUnrecognizedInteractions)
+
+	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "not a boolean")
+	config, err = NewFromEnv()
+	require.Error(t, err) // Parse error
+
+	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "0")
+	config, err = NewFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, false, config.RejectUnrecognizedInteractions)
+
+	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "1")
+	config, err = NewFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, true, config.RejectUnrecognizedInteractions)
+
+	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "2")
+	config, err = NewFromEnv()
+	require.Error(t, err) // Parse error
+
+	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "-1")
+	config, err = NewFromEnv()
+	require.Error(t, err) // Parse error
+}
+
 // gets a free port on the localhost and returns it as a url.
 func getFreePortURL() (*url.URL, error) {
 	port, err := utils.GetFreePort()

--- a/internal/app/configuration/proxyconfig_test.go
+++ b/internal/app/configuration/proxyconfig_test.go
@@ -183,43 +183,41 @@ func TestConfigureProxy_MTLS(t *testing.T) {
 	}
 }
 
-func TestProxyConfig_RejectUnrecognizedInteractions(t *testing.T) {
+func TestProxyConfig_ForwardUnrecognisedRequests(t *testing.T) {
 	os.Clearenv()
-	expectedDefaultValue := true
-
 	config, err := NewFromEnv()
 	require.NoError(t, err)
-	require.Equal(t, expectedDefaultValue, config.RejectUnrecognizedInteractions) // If no env var is specified it should default to true
+	require.Equal(t, false, config.ForwardUnrecognisedRequests) // If no env var is specified it should default to false
 
-	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "false")
+	os.Setenv("FORWARD_UNRECOGNIZED_REQUESTS", "false")
 	config, err = NewFromEnv()
 	require.NoError(t, err)
-	require.Equal(t, false, config.RejectUnrecognizedInteractions)
+	require.Equal(t, false, config.ForwardUnrecognisedRequests)
 
-	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "true")
+	os.Setenv("FORWARD_UNRECOGNIZED_REQUESTS", "true")
 	config, err = NewFromEnv()
 	require.NoError(t, err)
-	require.Equal(t, true, config.RejectUnrecognizedInteractions)
+	require.Equal(t, true, config.ForwardUnrecognisedRequests)
 
-	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "not a boolean")
+	os.Setenv("FORWARD_UNRECOGNIZED_REQUESTS", "not a boolean")
 	config, err = NewFromEnv()
 	require.Error(t, err) // Parse error
 
-	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "0")
+	os.Setenv("FORWARD_UNRECOGNIZED_REQUESTS", "0")
 	config, err = NewFromEnv()
 	require.NoError(t, err)
-	require.Equal(t, false, config.RejectUnrecognizedInteractions)
+	require.Equal(t, false, config.ForwardUnrecognisedRequests)
 
-	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "1")
+	os.Setenv("FORWARD_UNRECOGNIZED_REQUESTS", "1")
 	config, err = NewFromEnv()
 	require.NoError(t, err)
-	require.Equal(t, true, config.RejectUnrecognizedInteractions)
+	require.Equal(t, true, config.ForwardUnrecognisedRequests)
 
-	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "2")
+	os.Setenv("FORWARD_UNRECOGNIZED_REQUESTS", "2")
 	config, err = NewFromEnv()
 	require.Error(t, err) // Parse error
 
-	os.Setenv("REJECT_UNRECOGNIZED_INTERACTIONS", "-1")
+	os.Setenv("FORWARD_UNRECOGNIZED_REQUESTS", "-1")
 	config, err = NewFromEnv()
 	require.Error(t, err) // Parse error
 }

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -269,10 +269,9 @@ func (a *api) indexHandler(c echo.Context) error {
 	if !ok {
 		if a.rejectUnrecognizedInteractions {
 			return c.JSON(http.StatusBadRequest, httpresponse.Errorf("unable to find interaction to Match '%s %s'", req.Method, req.URL.Path))
-		} else {
-			// No interactions found, pass the request as is to pact mock server.
-			return a.ProxyRequest(c)
 		}
+		// No interactions found, pass the request as is to pact mock server.
+		return a.ProxyRequest(c)
 	}
 
 	data, err := io.ReadAll(req.Body)

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -23,15 +23,16 @@ const (
 )
 
 type Config struct {
-	ServerAddress url.URL       `env:"SERVER_ADDRESS"`      // Address to listen on
-	Proxies       []url.URL     `env:"PROXIES,delimiter=;"` // List of URL to serve pact-proxy on, e.g. http://localhost:8080;http://localhost:8081
-	WaitDelay     time.Duration `env:"WAIT_DELAY"`          // Default Delay for WaitForInteractions endpoint
-	WaitDuration  time.Duration `env:"WAIT_DURATION"`       // Default Duration for WaitForInteractions endpoint
-	RecordHistory bool          `env:"RECORD_HISTORY"`
-	TLSCAFile     string        `env:"TLS_CA_FILE"`
-	TLSCertFile   string        `env:"TLS_CERT_FILE"`
-	TLSKeyFile    string        `env:"TLS_KEY_FILE"`
-	Target        url.URL       // Do not load Target from env, we set this for each value from Proxies
+	ServerAddress                  url.URL       `env:"SERVER_ADDRESS"`      // Address to listen on
+	Proxies                        []url.URL     `env:"PROXIES,delimiter=;"` // List of URL to serve pact-proxy on, e.g. http://localhost:8080;http://localhost:8081
+	WaitDelay                      time.Duration `env:"WAIT_DELAY"`          // Default Delay for WaitForInteractions endpoint
+	WaitDuration                   time.Duration `env:"WAIT_DURATION"`       // Default Duration for WaitForInteractions endpoint
+	RecordHistory                  bool          `env:"RECORD_HISTORY"`
+	RejectUnrecognizedInteractions bool          `env:"REJECT_UNRECOGNIZED_INTERACTIONS,overwrite"` // Rejects requests that dont map to a registered interaction
+	TLSCAFile                      string        `env:"TLS_CA_FILE"`
+	TLSCertFile                    string        `env:"TLS_CERT_FILE"`
+	TLSKeyFile                     string        `env:"TLS_KEY_FILE"`
+	Target                         url.URL       // Do not load Target from env, we set this for each value from Proxies
 }
 
 var supportedMediaTypes = map[string]func([]byte, *url.URL) (requestDocument, error){
@@ -50,6 +51,7 @@ type api struct {
 	duration      time.Duration
 	recordHistory bool
 	echo.Context
+	rejectUnrecognizedInteractions bool
 }
 
 func (a *api) ProxyRequest(c echo.Context) error {
@@ -60,13 +62,14 @@ func (a *api) ProxyRequest(c echo.Context) error {
 func SetupRoutes(e *echo.Echo, config *Config) {
 	// Create these once at startup, thay are shared by all server threads
 	a := api{
-		target:        &config.Target,
-		proxy:         httputil.NewSingleHostReverseProxy(&config.Target),
-		interactions:  &Interactions{},
-		notify:        NewNotify(),
-		delay:         config.WaitDelay,
-		duration:      config.WaitDuration,
-		recordHistory: config.RecordHistory,
+		target:                         &config.Target,
+		proxy:                          httputil.NewSingleHostReverseProxy(&config.Target),
+		interactions:                   &Interactions{},
+		notify:                         NewNotify(),
+		delay:                          config.WaitDelay,
+		duration:                       config.WaitDuration,
+		recordHistory:                  config.RecordHistory,
+		rejectUnrecognizedInteractions: config.RejectUnrecognizedInteractions,
 	}
 	if a.delay == 0 {
 		a.delay = defaultDelay
@@ -264,7 +267,12 @@ func (a *api) indexHandler(c echo.Context) error {
 
 	allInteractions, ok := a.interactions.FindAll(req.URL.Path, req.Method)
 	if !ok {
-		return c.JSON(http.StatusBadRequest, httpresponse.Errorf("unable to find interaction to Match '%s %s'", req.Method, req.URL.Path))
+		if a.rejectUnrecognizedInteractions {
+			return c.JSON(http.StatusBadRequest, httpresponse.Errorf("unable to find interaction to Match '%s %s'", req.Method, req.URL.Path))
+		} else {
+			// No interactions found, pass the request as is to pact mock server.
+			return a.ProxyRequest(c)
+		}
 	}
 
 	data, err := io.ReadAll(req.Body)


### PR DESCRIPTION
`pact-proxy` returns an error to the caller when an endpoint is invoked that does not match any interaction URLs. This prevents the pact mock server from correctly receiving unexpected requests.

A new env variable is added to allow passing unrecognised requests to pact mock server. This in turns allows us to retreive unexpected requests when issuing a verification GET request.

This change is opt-in via the env var to preserve the default behaviour of `pact-proxy` in existing repositories.