### PR TITLE
feat: Add interaction not found error

### DIFF
--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -184,7 +184,7 @@ func (a *api) interactionsGetHandler(c echo.Context) error {
 	alias := c.Param("alias")
 	interaction, found := a.interactions.Load(alias)
 	if !found {
-		return c.JSON(http.StatusBadRequest, httpresponse.Errorf("interaction %q not found", alias))
+		return c.JSON(http.StatusNotFound, httpresponse.Errorf("interaction %q not found", alias))
 	}
 
 	return c.JSON(http.StatusOK, interaction)

--- a/internal/app/pactproxy/proxy_test.go
+++ b/internal/app/pactproxy/proxy_test.go
@@ -135,7 +135,7 @@ func TestInteractionsGetHandler(t *testing.T) {
 		{
 			name:         "interaction not found",
 			interactions: &Interactions{},
-			code:         http.StatusBadRequest,
+			code:         http.StatusNotFound,
 			body:         `{"error_message":"interaction \"test\" not found"}`,
 		},
 	} {

--- a/pkg/pactproxy/pactproxy.go
+++ b/pkg/pactproxy/pactproxy.go
@@ -14,6 +14,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var InteractionNotFoundError = errors.New("interaction not found")
+
 type PactProxy struct {
 	client http.Client
 	url    string
@@ -144,6 +146,9 @@ func (p *PactProxy) ReadInteractionDetails(alias string) (*Interaction, error) {
 		return nil, errors.Wrap(err, "http get")
 	}
 	if res.StatusCode != http.StatusOK {
+		if res.StatusCode == http.StatusNotFound {
+			return nil, InteractionNotFoundError
+		}
 		return nil, errors.New("fail")
 	}
 	interaction := &Interaction{}


### PR DESCRIPTION
The interaction details endpoint previously replied with a 400 if an interaction was not found. This PR changes it to a 404.

PactProxy now returns a defined error when a 404 is received from that endpoint, so that dependent tests can verify that the details were not returned due to the interaction not existing.

This allows tests using pact proxy to verify that a certain pact interaction was not registered with pact-proxy and gives confidence that the endpoint was not invoked.