### PR TITLE
Fix: Enable adding multiple modifiers based on attempt

### DIFF
--- a/internal/app/concurrent_proxy_test.go
+++ b/internal/app/concurrent_proxy_test.go
@@ -34,6 +34,17 @@ func TestConcurrentRequestsForSameModifierBasedOnAttempt(t *testing.T) {
 		the_second_user_response_should_have_the_right_status_code_and_body()
 }
 
+func TestMultipleModifiersForSameInteraction(t *testing.T) {
+	given, when, then := NewConcurrentProxyStage(t)
+	given.
+		a_pact_that_allows_any_names()
+	when.
+		the_concurrent_requests_are_sent_with_multiple_modifiers_for_same_interaction()
+	then.
+		all_responses_should_have_the_expected_return_values()
+
+}
+
 func TestConcurrentRequestsWaitForAllPacts(t *testing.T) {
 	given, when, then := NewConcurrentProxyStage(t)
 

--- a/internal/app/pactproxy/modifier.go
+++ b/internal/app/pactproxy/modifier.go
@@ -22,7 +22,13 @@ type interactionModifiers struct {
 }
 
 func (im *interactionModifier) Key() string {
-	return strings.Join([]string{im.Interaction, im.Path}, "_")
+	var key string
+	if im.Attempt != nil {
+		key = strings.Join([]string{im.Interaction, im.Path, strconv.Itoa(*im.Attempt)}, "_")
+	} else {
+		key = strings.Join([]string{im.Interaction, im.Path}, "_")
+	}
+	return key
 }
 
 func (ims *interactionModifiers) AddModifier(modifier *interactionModifier) {


### PR DESCRIPTION
There was a bug which meant that modifiers based on attempt count would
be overwitten because they were stored with the same key in the
modifiers map. We fix this by adding the attempt count to the key so
that now the keys are different and multiple modifiers can be added for
the same interaction based on attempt.