### PR TITLE
chore: support application/vnd.api+json content type

### DIFF
--- a/internal/app/pactproxy/interaction.go
+++ b/internal/app/pactproxy/interaction.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	mediaTypeJSON = "application/json"
-	mediaTypeText = "text/plain"
-	mediaTypeXml  = "application/xml"
-	mediaTypeCsv  = "text/csv"
+	mediaTypeJSON    = "application/json"
+	mediaTypeJSONAPI = "application/vnd.api+json"
+	mediaTypeText    = "text/plain"
+	mediaTypeXml     = "application/xml"
+	mediaTypeCsv     = "text/csv"
 )
 
 type pathMatcher interface {
@@ -116,7 +117,7 @@ func LoadInteraction(data []byte, alias string) (*Interaction, error) {
 	}
 
 	switch mediaType {
-	case mediaTypeJSON:
+	case mediaTypeJSON, mediaTypeJSONAPI:
 		interaction.addJSONConstraintsFromPact("$.body", propertiesWithMatchingRule, requestBody)
 		return interaction, nil
 	case mediaTypeText, mediaTypeCsv, mediaTypeXml:

--- a/internal/app/pactproxy/proxy.go
+++ b/internal/app/pactproxy/proxy.go
@@ -36,10 +36,11 @@ type Config struct {
 }
 
 var supportedMediaTypes = map[string]func([]byte, *url.URL) (requestDocument, error){
-	mediaTypeJSON: ParseJSONRequest,
-	mediaTypeText: ParsePlainTextRequest,
-	mediaTypeCsv:  ParsePlainTextRequest,
-	mediaTypeXml:  ParsePlainTextRequest,
+	mediaTypeJSON:    ParseJSONRequest,
+	mediaTypeJSONAPI: ParseJSONRequest,
+	mediaTypeText:    ParsePlainTextRequest,
+	mediaTypeCsv:     ParsePlainTextRequest,
+	mediaTypeXml:     ParsePlainTextRequest,
 }
 
 type api struct {

--- a/internal/app/proxy_stage_test.go
+++ b/internal/app/proxy_stage_test.go
@@ -117,18 +117,22 @@ func (s *ProxyStage) and() *ProxyStage {
 }
 
 func (s *ProxyStage) a_pact_that_allows_any_names() *ProxyStage {
+	return s.a_pact_that_allows_any_names_for_content("application/json")
+}
+
+func (s *ProxyStage) a_pact_that_allows_any_names_for_content(contentType string) *ProxyStage {
 	s.pact.
 		AddInteraction().
 		UponReceiving(s.pactName).
 		WithRequest(dsl.Request{
 			Method:  "POST",
 			Path:    dsl.String("/users"),
-			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String(contentType)},
 			Body:    dsl.MapMatcher{"name": dsl.Regex("any", ".*")},
 		}).
 		WillRespondWith(dsl.Response{
 			Status:  200,
-			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String(contentType)},
 			Body:    map[string]string{"name": "any"},
 		})
 	return s

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -89,6 +90,21 @@ func TestConstraintHeaderMatch(t *testing.T) {
 
 	when.
 		a_request_is_sent_using_the_name("sam")
+
+	then.
+		pact_verification_is_successful().and().
+		pact_can_be_generated()
+}
+
+func TestConstraintHeaderMatchJSONAPIContent(t *testing.T) {
+	given, when, then := NewProxyStage(t)
+
+	given.
+		a_pact_that_allows_any_names_for_content("application/vnd.api+json").and().
+		a_content_type_constraint_is_added("application/vnd.api+json")
+
+	when.
+		n_requests_are_sent_using_the_body_and_content_type(1, fmt.Sprintf(`{"name":"%s"}`, "sam"), "application/vnd.api+json")
 
 	then.
 		pact_verification_is_successful().and().


### PR DESCRIPTION
Accept the `application/vnd.api+json` Content-Type

### Proof of work

The test with "application/vnd.api+json" content type request are failing before applying the fix: https://github.com/form3tech-oss/pact-proxy/actions/runs/12674871237
with an error:

```
"unable to load interaction. unsupported media type application/vnd.api+json"
```

After the adding the fix the tests are green 🟢 
