### PR TITLE
fix: fix loading values from source last req

### DIFF
--- a/internal/app/pactproxy/interaction.go
+++ b/internal/app/pactproxy/interaction.go
@@ -333,7 +333,7 @@ func (i *Interaction) loadValuesFromSource(constraint interactionConstraint, int
 	}
 
 	for i, v := range constraint.Values {
-		values[i], _ = jsonpath.Get(v.(string), sourceRequest)
+		values[i], _ = jsonpath.Get(v.(string), map[string]interface{}(sourceRequest))
 	}
 
 	return values, nil

--- a/internal/app/pactproxy/interaction_test.go
+++ b/internal/app/pactproxy/interaction_test.go
@@ -618,3 +618,50 @@ func Test_getPathRegex(t *testing.T) {
 		})
 	}
 }
+
+func Test_loadValuesFromSource(t *testing.T) {
+	lastRequest := map[string]any{
+		"body": map[string]any{
+			"name": "sam",
+		},
+	}
+	tests := []*struct {
+		name              string
+		sourceInteraction *Interaction
+		constraints       interactionConstraint
+		want              interface{}
+		wantErr           bool
+	}{
+		{
+			name: "",
+			sourceInteraction: &Interaction{
+				Alias:       "first-interaction",
+				LastRequest: lastRequest,
+			},
+			constraints: interactionConstraint{
+				Interaction: "first-interaction",
+				Path:        "$.path",
+				Values:      []interface{}{"$.body.name"},
+				Format:      "/v1/resource/%s/subresource",
+				Source:      "",
+			},
+			want:    []interface{}{"sam"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Interaction{}
+			inter := &Interactions{}
+			inter.Store(tt.sourceInteraction)
+			got, err := i.loadValuesFromSource(tt.constraints, inter)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This will fix a problem with fetching the values from the source interaction last request. The problem occurs when the values from the source interaction are being used as a constraint. Due to the bug the json path library is unable to fetch the specified values from the source last request document.

### Proof of Work

The unit tests for `loadValuesFromSource` function fails without the fix : https://github.com/form3tech-oss/pact-proxy/actions/runs/12708671770/job/35426099780

After adding the fix the CI is green 🟢 